### PR TITLE
Add service worker kill switch for pre-rewrite migration

### DIFF
--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,54 @@
+/**
+ * Kill switch for the pre-rewrite service worker.
+ *
+ * The Qwik site registered its worker at /service-worker.js and precached
+ * every prerendered page (Workbox precaching serves those cache-first), so
+ * browsers that visited the old site keep rendering the old HTML from Cache
+ * Storage and never load the new app — which means they never get around to
+ * registering the current worker at /sw.js either.
+ *
+ * A registration is not dropped just because its script starts 404ing, so the
+ * only channel left is the update check the browser makes for this exact URL
+ * on every navigation. This file answers that check with a worker that has no
+ * fetch handler, wipes Cache Storage, unregisters itself and reloads whatever
+ * tabs it inherited. After that the browser goes to the network, gets the new
+ * app, and the new app registers /sw.js.
+ *
+ * Keep this file until the old worker is gone from the wild. Removing it makes
+ * /service-worker.js 404 again, which strands anyone who has not been back
+ * since — the redeploy would silently re-open the trap for those users.
+ */
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      // Take over the tabs the old worker was controlling so we can reload
+      // them below.
+      await self.clients.claim();
+
+      // Drops the old precache ("static"), the old NetworkFirst cache
+      // ("dynamic") and the old analyzer runtime, whose files lived under a
+      // path the new app no longer uses.
+      const cacheNames = await caches.keys();
+      await Promise.all(cacheNames.map((name) => caches.delete(name)));
+
+      await self.registration.unregister();
+
+      const windows = await self.clients.matchAll({ type: 'window' });
+      await Promise.all(
+        windows.map(async (client) => {
+          try {
+            await client.navigate(client.url);
+          } catch {
+            // Best effort: a client we cannot navigate picks up the new app on
+            // its next reload anyway, since nothing intercepts fetches now.
+          }
+        }),
+      );
+    })(),
+  );
+});

--- a/libs/pwa/src/sw-client.ts
+++ b/libs/pwa/src/sw-client.ts
@@ -21,12 +21,41 @@ function getChannel(): BroadcastChannel | null {
   return new BroadcastChannel('service-worker');
 }
 
+const SW_URL = '/sw.js';
+
+function scriptUrlOf(registration: ServiceWorkerRegistration): string | null {
+  const worker =
+    registration.active ?? registration.waiting ?? registration.installing;
+  return worker ? new URL(worker.scriptURL).pathname : null;
+}
+
+/**
+ * The pre-rewrite site registered its worker at /service-worker.js. Such a
+ * registration outlives a redeploy, so drop anything that is not the current
+ * worker before registering — otherwise a stale worker keeps serving its own
+ * precached copy of the app.
+ */
+async function unregisterStaleWorkers() {
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(
+    registrations
+      .filter((registration) => {
+        const script = scriptUrlOf(registration);
+        return script !== null && script !== SW_URL;
+      })
+      .map((registration) => registration.unregister()),
+  );
+}
+
 export function registerServiceWorker() {
   if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
   if (!import.meta.env.PROD) return;
-  navigator.serviceWorker.register('/sw.js').catch((e) => {
-    console.warn('Service worker registration failed', e);
-  });
+  void unregisterStaleWorkers()
+    .catch(() => undefined)
+    .then(() => navigator.serviceWorker.register(SW_URL))
+    .catch((e) => {
+      console.warn('Service worker registration failed', e);
+    });
 }
 
 export async function isServiceWorkerActive(): Promise<boolean> {

--- a/tools/scripts/build-sw.mts
+++ b/tools/scripts/build-sw.mts
@@ -71,6 +71,9 @@ const { count, size, warnings } = await injectManifest({
     'analyzer-deps-manifest.json',
     'mock-data.json.gz',
     'sw.js',
+    // legacy kill switch: must always be fetched from the network, never
+    // served out of the precache
+    'service-worker.js',
     'pwa/html_code.html',
   ],
   maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,

--- a/vercel.json
+++ b/vercel.json
@@ -90,6 +90,12 @@
       ]
     },
     {
+      "source": "/service-worker.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
       "source": "/pid-analyzer-dependencies/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Summary
This PR implements a kill switch mechanism to safely migrate users from the old Qwik-based service worker to the new application. The old worker at `/service-worker.js` was precaching all pages, causing browsers to serve stale HTML from cache and never load the new app.

## Key Changes
- **New kill switch worker** (`apps/web/public/service-worker.js`): A minimal service worker that activates on update checks, clears all caches, unregisters itself, and reloads affected tabs to force users to fetch the new app
- **Stale worker cleanup** (`libs/pwa/src/sw-client.ts`): Added `unregisterStaleWorkers()` function that runs before registering the new worker at `/sw.js`, removing any legacy registrations from previous deployments
- **Cache headers** (`vercel.json`): Added no-cache headers for `/service-worker.js` to ensure browsers always check for updates
- **Build configuration** (`tools/scripts/build-sw.mts`): Excluded the kill switch from precaching so it's always fetched fresh from the network

## Implementation Details
The solution leverages the browser's automatic update check mechanism: even when a service worker script returns 404, the browser continues checking that URL on every navigation. By serving a minimal worker that clears caches and reloads tabs, users are forced to fetch the new application. The kill switch should be retained until the old worker is completely gone from the wild, as removing it would re-create the trap for users who haven't visited since the previous deployment.

https://claude.ai/code/session_01GDedkKg3y6yXfcJazzVaVa