### PR TITLE
Migrate analytics from Matomo to Umami

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-# Self-hosted Matomo instance (optional; analytics is disabled when unset)
-VITE_MATOMO_HOST=analytics.janjaap.de
+# Self-hosted Umami instance (optional; analytics is disabled when either is unset)
+VITE_UMAMI_HOST=analytics.janjaap.de
+VITE_UMAMI_WEBSITE_ID=

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,7 +6,6 @@
 **/test-output
 apps/web/public/pid-analyzer-dependencies
 apps/web/public/mock-data.json.gz
-apps/web/public/matomo.js
 **/routeTree.gen.ts
 i18n-stories
 pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ directly.
 Vercel builds via `vercel.json` (install → build → SW → SEO) and serves
 `apps/web/dist/client` as a static site, including permanent redirects for
 all legacy URLs. The only runtime configuration is the optional
-`VITE_MATOMO_HOST` for self-hosted, ad-free analytics.
+`VITE_UMAMI_HOST` / `VITE_UMAMI_WEBSITE_ID` pair for self-hosted, cookieless,
+ad-free analytics.
 
 ## Credits
 

--- a/apps/web/src/analytics.ts
+++ b/apps/web/src/analytics.ts
@@ -1,55 +1,94 @@
 /**
- * Matomo-only analytics (port of the original utils/analytics.ts, minus
- * Vercel Analytics and ads). Cookieless-friendly self-hosted instance;
- * the tracker script is loaded as "not_matomo.js" from the analytics host
- * to survive overzealous adblockers — same trick as before.
+ * Umami analytics. Cookieless by design — no cookies, no cross-site
+ * identifiers, no personal data leaving our own infrastructure.
+ *
+ * Auto-tracking is disabled so page views follow the router instead of the
+ * history API, which keeps SPA navigations from being counted twice. The
+ * tracker script is loaded asynchronously, so anything tracked before it is
+ * ready is queued and flushed once it loads.
  */
+
+type UmamiEventData = Record<string, string | number | boolean>;
+type UmamiPayload = Record<string, unknown>;
 
 declare global {
   interface Window {
-    Matomo?: {
-      getTracker: () => {
-        trackEvent: (
-          category: string,
-          action: string,
-          name?: string,
-          value?: number,
-        ) => void;
+    umami?: {
+      track: {
+        (payload: (props: UmamiPayload) => UmamiPayload): void;
+        (eventName: string, eventData?: UmamiEventData): void;
       };
     };
-    _paq?: unknown[][];
   }
 }
 
-const MATOMO_HOST = import.meta.env['VITE_MATOMO_HOST'] as string | undefined;
+const UMAMI_HOST = import.meta.env['VITE_UMAMI_HOST'] as string | undefined;
+const UMAMI_WEBSITE_ID = import.meta.env['VITE_UMAMI_WEBSITE_ID'] as
+  | string
+  | undefined;
 
-export function initAnalytics() {
-  if (!MATOMO_HOST || !import.meta.env.PROD) return;
-  if (typeof window === 'undefined' || window._paq) return;
+let initialized = false;
+let pending: Array<() => void> | null = [];
 
-  const host = `//${MATOMO_HOST}/`;
-  const _paq: unknown[][] = (window._paq = window._paq ?? []);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  _paq.push(['setTrackerUrl', `${host}matomo.php`]);
-  _paq.push(['setSiteId', '1']);
-
-  const script = document.createElement('script');
-  script.async = true;
-  script.src = `${host}not_matomo.js`;
-  document.head.appendChild(script);
-}
-
-export function trackPageView(url: string) {
-  window._paq?.push(['setCustomUrl', url]);
-  window._paq?.push(['trackPageView']);
-}
-
-export function trackEvent(category: string, action: string) {
-  if (!window.Matomo) return;
+function enqueue(run: () => void) {
+  if (!initialized) return;
+  if (pending) {
+    pending.push(run);
+    return;
+  }
   try {
-    window.Matomo.getTracker().trackEvent(category, action, `${category}:${action}`, 1);
+    run();
   } catch {
     // analytics must never break the app
   }
+}
+
+function flush() {
+  const queued = pending ?? [];
+  pending = null;
+  for (const run of queued) {
+    try {
+      run();
+    } catch {
+      // analytics must never break the app
+    }
+  }
+}
+
+export function initAnalytics() {
+  if (!UMAMI_HOST || !UMAMI_WEBSITE_ID || !import.meta.env.PROD) return;
+  if (typeof window === 'undefined' || initialized) return;
+
+  initialized = true;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://${UMAMI_HOST}/script.js`;
+  script.setAttribute('data-website-id', UMAMI_WEBSITE_ID);
+  // We drive page views from the router ourselves.
+  script.setAttribute('data-auto-track', 'false');
+  // Respect the browser's "Do Not Track" setting.
+  script.setAttribute('data-do-not-track', 'true');
+  script.addEventListener('load', flush);
+  script.addEventListener('error', () => {
+    // Blocked or unreachable — drop the queue and stop collecting.
+    pending = null;
+    initialized = false;
+  });
+  document.head.appendChild(script);
+
+  trackPageView(window.location.pathname + window.location.search);
+}
+
+export function trackPageView(url: string) {
+  // Umami records the URL relative to the site root; strip the origin so
+  // absolute hrefs from the router end up in the same shape.
+  const path = url.replace(/^https?:\/\/[^/]+/, '') || '/';
+  enqueue(() => window.umami?.track((props) => ({ ...props, url: path })));
+}
+
+export function trackEvent(category: string, action: string) {
+  enqueue(() =>
+    window.umami?.track(`${category}:${action}`, { category, action }),
+  );
 }

--- a/libs/content/src/de/data-privacy.mdx
+++ b/libs/content/src/de/data-privacy.mdx
@@ -27,7 +27,7 @@ Diese Website wird bei Vercel Inc. (USA) gehostet. Beim Besuch der Seite verarbe
 
 ## Webanalyse
 
-Wir nutzen eine selbst gehostete Instanz der Open-Source-Software Matomo, um zu verstehen, welche Seiten am meisten genutzt werden. Die Daten werden auf unserer eigenen Infrastruktur verarbeitet und **nicht an Dritte weitergegeben**. IP-Adressen werden anonymisiert. Du kannst die Analyse verhindern, indem du „Do Not Track" in deinem Browser aktivierst oder einen Content-Blocker verwendest — die Seite funktioniert auch ohne vollständig.
+Wir nutzen eine selbst gehostete Instanz der Open-Source-Software Umami, um zu verstehen, welche Seiten am meisten genutzt werden. Die Daten werden auf unserer eigenen Infrastruktur verarbeitet und **nicht an Dritte weitergegeben**. Umami kommt ohne Cookies aus und speichert keine IP-Adressen — deine IP und Browser-Angaben werden lediglich verwendet, um daraus eine kurzlebige, anonyme Kennung abzuleiten, die sich weder dir zuordnen noch über Websites hinweg verfolgen lässt. Du kannst die Analyse verhindern, indem du „Do Not Track" in deinem Browser aktivierst oder einen Content-Blocker verwendest — die Seite funktioniert auch ohne vollständig.
 
 ## Lokaler Speicher und Offline-Caches
 
@@ -45,4 +45,4 @@ Du hast das Recht auf Auskunft über die Verarbeitung deiner personenbezogenen D
 
 Wir behalten uns vor, diese Datenschutzerklärung anzupassen, um sie an geänderte rechtliche Anforderungen oder Änderungen im Betrieb unserer Website anzupassen. Bitte prüfe diese Seite regelmäßig auf Aktualisierungen.
 
-Stand: Juli 2026
+Stand: August 2026

--- a/libs/content/src/en/data-privacy.mdx
+++ b/libs/content/src/en/data-privacy.mdx
@@ -27,7 +27,7 @@ This website is hosted by Vercel Inc. (USA). When you visit the site, Vercel tec
 
 ## Analytics
 
-We use a self-hosted instance of the open-source software Matomo to understand which pages are used most. The data is processed on our own infrastructure and is **not shared with third parties**. IP addresses are anonymized. You can prevent analytics by enabling "Do Not Track" in your browser or by using a content blocker — the site works fully without it.
+We use a self-hosted instance of the open-source software Umami to understand which pages are used most. The data is processed on our own infrastructure and is **not shared with third parties**. Umami works without cookies and does not store IP addresses — your IP and browser details are only used to derive a short-lived, anonymous identifier that cannot be traced back to you or followed across websites. You can prevent analytics by enabling "Do Not Track" in your browser or by using a content blocker — the site works fully without it.
 
 ## Local storage and offline caches
 
@@ -45,4 +45,4 @@ You have the right to obtain information about the processing of your personal d
 
 We reserve the right to amend this privacy policy in order to adapt it to changes in legal requirements or changes in the operation of our website. Please check this page regularly for updates.
 
-Last updated: July 2026
+Last updated: August 2026

--- a/libs/content/src/es/data-privacy.mdx
+++ b/libs/content/src/es/data-privacy.mdx
@@ -27,7 +27,7 @@ Este sitio web está alojado por Vercel Inc. (EE. UU.). Cuando visitas el sitio,
 
 ## Analítica
 
-Utilizamos una instancia autoalojada del software de código abierto Matomo para entender qué páginas se usan más. Los datos se procesan en nuestra propia infraestructura y **no se comparten con terceros**. Las direcciones IP se anonimizan. Puedes evitar la analítica activando "Do Not Track" en tu navegador o utilizando un bloqueador de contenido: el sitio funciona perfectamente sin ella.
+Utilizamos una instancia autoalojada del software de código abierto Umami para entender qué páginas se usan más. Los datos se procesan en nuestra propia infraestructura y **no se comparten con terceros**. Umami funciona sin cookies y no almacena direcciones IP: tu IP y los datos de tu navegador solo se utilizan para derivar un identificador anónimo y de corta duración que no puede vincularse contigo ni seguirte entre sitios web. Puedes evitar la analítica activando "Do Not Track" en tu navegador o utilizando un bloqueador de contenido: el sitio funciona perfectamente sin ella.
 
 ## Almacenamiento local y cachés sin conexión
 
@@ -45,4 +45,4 @@ Tienes derecho a obtener información sobre el tratamiento de tus datos personal
 
 Nos reservamos el derecho de modificar esta política de privacidad para adaptarla a cambios en los requisitos legales o en el funcionamiento de nuestro sitio web. Por favor, revisa esta página periódicamente para estar al día.
 
-Última actualización: julio de 2026
+Última actualización: agosto de 2026

--- a/libs/content/src/fr/data-privacy.mdx
+++ b/libs/content/src/fr/data-privacy.mdx
@@ -27,7 +27,7 @@ Ce site web est hébergé par Vercel Inc. (États-Unis). Lorsque tu visites le s
 
 ## Statistiques
 
-Nous utilisons une instance auto-hébergée du logiciel open source Matomo pour comprendre quelles pages sont les plus consultées. Les données sont traitées sur notre propre infrastructure et ne sont **pas partagées avec des tiers**. Les adresses IP sont anonymisées. Tu peux empêcher la collecte de statistiques en activant « Do Not Track » dans ton navigateur ou en utilisant un bloqueur de contenu — le site fonctionne parfaitement sans.
+Nous utilisons une instance auto-hébergée du logiciel open source Umami pour comprendre quelles pages sont les plus consultées. Les données sont traitées sur notre propre infrastructure et ne sont **pas partagées avec des tiers**. Umami fonctionne sans cookies et ne conserve pas les adresses IP : ton IP et les informations de ton navigateur servent uniquement à dériver un identifiant anonyme et éphémère, qui ne peut ni t'être rattaché ni te suivre d'un site à l'autre. Tu peux empêcher la collecte de statistiques en activant « Do Not Track » dans ton navigateur ou en utilisant un bloqueur de contenu — le site fonctionne parfaitement sans.
 
 ## Stockage local et caches hors ligne
 
@@ -45,4 +45,4 @@ Tu as le droit d'obtenir des informations sur le traitement de tes données pers
 
 Nous nous réservons le droit de modifier cette politique de confidentialité afin de l'adapter à l'évolution des exigences légales ou à des changements dans l'exploitation de notre site web. Merci de consulter cette page régulièrement pour rester informé.
 
-Dernière mise à jour : juillet 2026
+Dernière mise à jour : août 2026

--- a/libs/content/src/pl/data-privacy.mdx
+++ b/libs/content/src/pl/data-privacy.mdx
@@ -27,7 +27,7 @@ Ta strona jest hostowana przez Vercel Inc. (USA). Gdy odwiedzasz stronę, Vercel
 
 ## Analityka
 
-Korzystamy z własnej (self-hosted) instancji oprogramowania open-source Matomo, aby dowiedzieć się, które strony są używane najczęściej. Dane są przetwarzane na naszej własnej infrastrukturze i **nie są udostępniane podmiotom trzecim**. Adresy IP są anonimizowane. Możesz zablokować analitykę, włączając w przeglądarce funkcję „Do Not Track" lub używając blokera treści — strona działa w pełni również bez analityki.
+Korzystamy z własnej (self-hosted) instancji oprogramowania open-source Umami, aby dowiedzieć się, które strony są używane najczęściej. Dane są przetwarzane na naszej własnej infrastrukturze i **nie są udostępniane podmiotom trzecim**. Umami działa bez plików cookie i nie przechowuje adresów IP — Twój adres IP i dane przeglądarki służą wyłącznie do wygenerowania krótkotrwałego, anonimowego identyfikatora, którego nie da się powiązać z Tobą ani śledzić pomiędzy witrynami. Możesz zablokować analitykę, włączając w przeglądarce funkcję „Do Not Track" lub używając blokera treści — strona działa w pełni również bez analityki.
 
 ## Pamięć lokalna i pamięć podręczna offline
 
@@ -45,4 +45,4 @@ Masz prawo do uzyskania informacji o przetwarzaniu Twoich danych osobowych, a ta
 
 Zastrzegamy sobie prawo do zmiany niniejszej polityki prywatności w celu dostosowania jej do zmian wymogów prawnych lub zmian w działaniu naszej strony internetowej. Prosimy o regularne sprawdzanie tej strony pod kątem aktualizacji.
 
-Ostatnia aktualizacja: lipiec 2026
+Ostatnia aktualizacja: sierpień 2026


### PR DESCRIPTION
## Summary
Replaces the self-hosted Matomo analytics implementation with Umami, a privacy-focused alternative that operates without cookies and doesn't store IP addresses.

## Key Changes

- **Analytics library migration**: Switched from Matomo to Umami with updated API calls
  - Changed from `window._paq` array-based tracking to `window.umami.track()` method
  - Updated environment variables from `VITE_MATOMO_HOST` to `VITE_UMAMI_HOST` and added `VITE_UMAMI_WEBSITE_ID`

- **Improved initialization logic**: 
  - Implemented a queue-based system to handle analytics calls before the tracker script loads
  - Added `enqueue()` and `flush()` functions to ensure tracking events are buffered and executed once Umami is ready
  - Script now respects "Do Not Track" browser setting via `data-do-not-track` attribute
  - Disabled auto-tracking to prevent double-counting of SPA navigations

- **Enhanced error handling**: 
  - Script load/error event listeners properly manage initialization state
  - Analytics failures are caught and never break the application

- **Updated documentation**:
  - Privacy policy pages (DE, EN, ES, FR, PL) updated to reflect Umami's cookieless approach and anonymous identifier generation
  - README updated with new environment variable names
  - Removed Matomo-specific entries from `.prettierignore`

## Notable Implementation Details

- Page view tracking now normalizes URLs by stripping the origin, ensuring consistent path recording
- Event tracking combines category and action into a single event name (`category:action`) with metadata
- The tracker script is loaded asynchronously with proper queue management to handle early tracking calls
- Umami's short-lived, anonymous identifiers cannot be traced back to users or followed across websites

https://claude.ai/code/session_01YESoEQwTRGTDxWAviFSAL2